### PR TITLE
feat(husky): Implemented husky commit-msg file to check for valid com…

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+# Load husky
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Read commit message
+message=$(cat "$1")
+
+# Regex pattern
+requiredPattern="^(build|chore|feat|fix|docs|refactor|perf|style|test)\([a-zA-Z0-9\s\-_]+\): .+$"
+
+# Check if the commit message is valid
+if ! echo "$message" | grep -iqE "$requiredPattern"; then
+  cat <<EOF
+.
+.
+Oh no! Tu commit message tiene el formato incorrecto :(
+El message debe de estar en el siguiente formato:
+<type>(<scope>): <subject>
+Los 'type' aceptados son: build, chore, feat, fix, docs, refactor, perf, style, test
+Ejemplo: fix(middleware): ensure Range headers adhere more closely to RFC 2616
+.
+Tu message fue:
+$message
+.
+Si quieres conocer más sobre este estándar, visita: https://dev.to/ishanmakadia/git-commit-message-convention-that-you-can-follow-1709
+.
+No te preocupes, intenta de nuevo. TQM <3
+EOF
+
+  # Exit with error status
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "mocha",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepare": "husky install"
   },
   "mocha": {
     "require": "ts-node/register",
@@ -48,6 +49,7 @@
     "prisma": "^5.10.2",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "husky": "^8.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ devDependencies:
   eslint-plugin-prettier:
     specifier: ^5.1.3
     version: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
+  husky:
+    specifier: ^8.0.0
+    version: 8.0.3
   mocha:
     specifier: ^10.3.0
     version: 10.3.0
@@ -1752,6 +1755,12 @@ packages:
       statuses: 2.0.1
       toidentifier: 1.0.1
     dev: false
+
+  /husky@8.0.3:
+    resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}


### PR DESCRIPTION
# Husky Commit Hook

## Description

Implementación de un hook de Husky para validar los mensajes de commit antes de que se guarden en el repositorio. El hook se encarga de asegurar que los mensajes de commit cumplan con ciertos criterios de calidad, incluyendo: 

1. **Prefijo**: todos los mensajes de commit deben comenzar con un prefijo que indique el tipo de cambio realizado (por ejemplo, "feat" para nuevas características, "fix" para correcciones, "docs" para cambios en la documentación, etc.).
2. **Formato**: se requiere un formato consistente para los mensajes de commit. 

## Funcionamiento

![image](https://github.com/Black-Dot-2024/Zeitgeist-Backend/assets/75867326/802d76bf-a475-4ed7-971f-ae74f81dc73d)