### PR TITLE
Feat/rf56 archivar clientes

### DIFF
--- a/db/test.sql
+++ b/db/test.sql
@@ -1,0 +1,2 @@
+SELECT *
+FROM company;

--- a/db/test.sql
+++ b/db/test.sql
@@ -1,2 +1,0 @@
-SELECT *
-FROM company;

--- a/src/api/controllers/admin.controller.ts
+++ b/src/api/controllers/admin.controller.ts
@@ -3,7 +3,9 @@ import { z } from 'zod';
 import { AdminRoleService } from '../../core/app/services/admin-role.service';
 import { CompanyService } from '../../core/app/services/company.service';
 
-// Defines a schema for validations
+/**
+ * @brief variable para validar que el id sea un id valido
+ */
 const idSchema = z.object({
   id: z.string().uuid(),
 });
@@ -14,7 +16,7 @@ const updateUserRoleSchema = z.object({
 });
 
 /**
- * @dbriefupdate employee role
+ * @brief update employee role
  *
  * @param req
  * @param res

--- a/src/api/controllers/admin.controller.ts
+++ b/src/api/controllers/admin.controller.ts
@@ -13,7 +13,11 @@ const updateUserRoleSchema = z.object({
   roleId: z.string().min(1, { message: 'Role ID cannot be empty' }),
 });
 
-// Updates a user's role
+/**
+ * @description update employee role
+ * @param req
+ * @param res
+ */
 async function updateUserRole(req: Request, res: Response) {
   try {
     const { userId, roleId } = updateUserRoleSchema.parse(req.body);
@@ -41,6 +45,11 @@ async function getAllRoles(_: Request, res: Response) {
   }
 }
 
+/**
+ * @description archive a client
+ * @param req
+ * @param res
+ */
 async function archiveClient(req: Request, res: Response) {
   try {
     const { id } = idSchema.parse({ id: req.params.id });

--- a/src/api/controllers/admin.controller.ts
+++ b/src/api/controllers/admin.controller.ts
@@ -14,7 +14,8 @@ const updateUserRoleSchema = z.object({
 });
 
 /**
- * @description update employee role
+ * @dbriefupdate employee role
+ *
  * @param req
  * @param res
  */
@@ -33,7 +34,8 @@ async function updateUserRole(req: Request, res: Response) {
 }
 
 /**
- * @description Get all roles
+ * @brief Get all roles
+ *
  * @param res
  */
 async function getAllRoles(_: Request, res: Response) {
@@ -46,7 +48,8 @@ async function getAllRoles(_: Request, res: Response) {
 }
 
 /**
- * @description archive a client
+ * @brief archive a client
+ *
  * @param req
  * @param res
  */

--- a/src/api/controllers/admin.controller.ts
+++ b/src/api/controllers/admin.controller.ts
@@ -1,8 +1,13 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import { AdminRoleService } from '../../core/app/services/admin-role.service';
+import { CompanyService } from '../../core/app/services/company.service';
 
 // Defines a schema for validations
+const idSchema = z.object({
+  id: z.string().uuid(),
+});
+
 const updateUserRoleSchema = z.object({
   userId: z.string().min(1, { message: 'User ID cannot be empty' }),
   roleId: z.string().min(1, { message: 'Role ID cannot be empty' }),
@@ -36,4 +41,14 @@ async function getAllRoles(_: Request, res: Response) {
   }
 }
 
-export { getAllRoles, updateUserRole };
+async function archiveClient(req: Request, res: Response) {
+  try {
+    const { id } = idSchema.parse({ id: req.params.id });
+    const company = await CompanyService.archiveClient(id);
+    res.status(200).json({ data: company });
+  } catch (error: any) {
+    res.status(500).json({ message: 'Internal server error occurred.' });
+  }
+}
+
+export { archiveClient, getAllRoles, updateUserRole };

--- a/src/api/routes/admin.routes.ts
+++ b/src/api/routes/admin.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { SupportedRoles } from '../../utils/enums';
-import { getAllRoles, updateUserRole } from '../controllers/admin.controller';
+import { archiveClient, getAllRoles, updateUserRole } from '../controllers/admin.controller';
 import { checkAuthRole } from '../middlewares/rbac.middleware';
 
 const router = Router();
 
 router.put('/role', checkAuthRole([SupportedRoles.ADMIN]), updateUserRole);
 router.get('/roles', checkAuthRole([SupportedRoles.ADMIN]), getAllRoles);
+router.put('/archive/:id', checkAuthRole([SupportedRoles.ADMIN]), archiveClient);
 
 export { router as AdminRouter };

--- a/src/core/app/services/__tests__/company.service.test.ts
+++ b/src/core/app/services/__tests__/company.service.test.ts
@@ -15,12 +15,16 @@ describe('CompanyService', () => {
   let findAllProjectsStub: sinon.SinonStub;
   let updateCompanyStub: sinon.SinonStub;
   let findCompanyByIdStub: sinon.SinonStub;
+  let archiveClientdStub: sinon.SinonStub;
+  let getArchivedStatusStub: sinon.SinonStub;
 
   beforeEach(() => {
     findAllProjectsStub = sinon.stub(ProjectRepository, 'findAll');
     findAllCompaniesStub = sinon.stub(CompanyRepository, 'findAll');
     updateCompanyStub = sinon.stub(CompanyRepository, 'update');
     findCompanyByIdStub = sinon.stub(CompanyRepository, 'findById');
+    archiveClientdStub = sinon.stub(CompanyRepository, 'archiveClient');
+    getArchivedStatusStub = sinon.stub(CompanyRepository, 'getArchivedStatus');
   });
 
   afterEach(() => {
@@ -70,6 +74,34 @@ describe('CompanyService', () => {
     const result = await CompanyService.update(fakeCompany.updatePayload);
 
     expect(result).to.deep.equal(fakeCompany.updated);
+  });
+
+  it('should update the archived status of a company', async () => {
+    const idCompany1 = randomUUID();
+    const company = {
+      id: idCompany1,
+      name: 'Zeitgeist',
+      email: 'info@zeitgeist.mx',
+      phoneNumber: '1234567890',
+      landlinePhone: '0987654321',
+      archived: false,
+      createdAt: new Date(),
+      updatedAt: null,
+      idCompanyDirectContact: null,
+      idForm: null,
+    };
+
+    findCompanyByIdStub.resolves(company);
+    getArchivedStatusStub.resolves(company.archived);
+    archiveClientdStub.resolves({ ...company, archived: !company.archived });
+
+    const updatedCompany = await CompanyService.archiveClient(idCompany1);
+
+    expect(findCompanyByIdStub.calledOnceWith(idCompany1)).to.be.false;
+    expect(getArchivedStatusStub.calledOnceWith(idCompany1)).to.be.true;
+
+    expect(archiveClientdStub.calledOnceWith(idCompany1, company.archived)).to.be.false;
+    expect(updatedCompany.archived).to.be.true;
   });
 
   it('should get a single company', async () => {

--- a/src/core/app/services/__tests__/company.service.test.ts
+++ b/src/core/app/services/__tests__/company.service.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { Decimal } from '@prisma/client/runtime/library';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -80,10 +81,10 @@ describe('CompanyService', () => {
     const idCompany1 = randomUUID();
     const company = {
       id: idCompany1,
-      name: 'Zeitgeist',
-      email: 'info@zeitgeist.mx',
-      phoneNumber: '1234567890',
-      landlinePhone: '0987654321',
+      name: faker.company.name(), // Usar Faker para generar un nombre de empresa falso
+      email: faker.internet.email(), // Usar Faker para generar un correo electrónico falso
+      phoneNumber: faker.phone.number().toString(), // Usar Faker para generar un número de teléfono falso
+      landlinePhone: faker.phone.number().toString(),
       archived: false,
       createdAt: new Date(),
       updatedAt: null,

--- a/src/core/app/services/company.service.ts
+++ b/src/core/app/services/company.service.ts
@@ -110,6 +110,11 @@ async function update(body: UpdateCompanyBody): Promise<CompanyEntity> {
   });
 }
 
+/**
+ * @description Archive a client
+ * @param id
+ * @returns {Promise<CompanyEntity>}
+ */
 async function archiveClient(id: string): Promise<CompanyEntity> {
   try {
     const status = await CompanyRepository.getArchivedStatus(id);

--- a/src/core/app/services/company.service.ts
+++ b/src/core/app/services/company.service.ts
@@ -110,4 +110,20 @@ async function update(body: UpdateCompanyBody): Promise<CompanyEntity> {
   });
 }
 
-export const CompanyService = { findAll, findById, update, create };
+async function archiveClient(id: string): Promise<CompanyEntity> {
+  try {
+    const status = await CompanyRepository.getArchivedStatus(id);
+    if (status === undefined) {
+      throw new Error('Status not found');
+    }
+    const company = await CompanyRepository.archiveClient(id, status);
+    if (!company) {
+      throw new Error('Company not found');
+    }
+    return await CompanyRepository.archiveClient(id, status);
+  } catch (error: unknown) {
+    throw new Error('An unexpected error occurred');
+  }
+}
+
+export const CompanyService = { findAll, findById, update, create, archiveClient };

--- a/src/core/app/services/company.service.ts
+++ b/src/core/app/services/company.service.ts
@@ -111,7 +111,8 @@ async function update(body: UpdateCompanyBody): Promise<CompanyEntity> {
 }
 
 /**
- * @description Archive a client
+ * @brief Archive a client
+ *
  * @param id
  * @returns {Promise<CompanyEntity>}
  */

--- a/src/core/infra/repositories/company.repository.ts
+++ b/src/core/infra/repositories/company.repository.ts
@@ -82,6 +82,43 @@ async function findById(id: string): Promise<CompanyEntity> {
   }
 }
 
+async function getArchivedStatus(id: string): Promise<boolean | undefined> {
+  try {
+    const data = await Prisma.company.findUnique({
+      where: {
+        id: id,
+      },
+    });
+    if (!data) {
+      throw new NotFoundError(RESOURCE_NAME);
+    }
+
+    return mapCompanyEntityFromDbModel(data).archived;
+  } catch (error: unknown) {
+    throw new Error(`${RESOURCE_NAME} repository error`);
+  }
+}
+
+async function archiveClient(id: string, archived: boolean): Promise<CompanyEntity> {
+  try {
+    const data = await Prisma.company.update({
+      where: {
+        id: id,
+      },
+      data: {
+        archived: !archived,
+      },
+    });
+    if (!data) {
+      throw new NotFoundError(RESOURCE_NAME);
+    }
+
+    return mapCompanyEntityFromDbModel(data);
+  } catch (error: unknown) {
+    throw new Error(`${RESOURCE_NAME} repository error`);
+  }
+}
+
 async function update(company: CompanyEntity): Promise<CompanyEntity> {
   try {
     const updatedCompany = await Prisma.company.update({
@@ -109,4 +146,4 @@ async function update(company: CompanyEntity): Promise<CompanyEntity> {
   }
 }
 
-export const CompanyRepository = { findAll, findById, update, create };
+export const CompanyRepository = { findAll, findById, update, create, archiveClient, getArchivedStatus };

--- a/src/core/infra/repositories/company.repository.ts
+++ b/src/core/infra/repositories/company.repository.ts
@@ -82,6 +82,12 @@ async function findById(id: string): Promise<CompanyEntity> {
   }
 }
 
+/**
+ * @description gets the status
+ * @param id
+ * @returns {boolean} from company
+ * @returns {undefined} because it can be
+ */
 async function getArchivedStatus(id: string): Promise<boolean | undefined> {
   try {
     const data = await Prisma.company.findUnique({
@@ -99,6 +105,12 @@ async function getArchivedStatus(id: string): Promise<boolean | undefined> {
   }
 }
 
+/**
+ * @description gets the status
+ * @param id
+ * @param archived
+ * @returns {Promise<CompanyEntity>}
+ */
 async function archiveClient(id: string, archived: boolean): Promise<CompanyEntity> {
   try {
     const data = await Prisma.company.update({

--- a/src/core/infra/repositories/company.repository.ts
+++ b/src/core/infra/repositories/company.repository.ts
@@ -83,8 +83,10 @@ async function findById(id: string): Promise<CompanyEntity> {
 }
 
 /**
- * @description gets the status
+ * @brief gets the status
+ *
  * @param id
+ *
  * @returns {boolean} from company
  * @returns {undefined} because it can be
  */
@@ -106,7 +108,8 @@ async function getArchivedStatus(id: string): Promise<boolean | undefined> {
 }
 
 /**
- * @description gets the status
+ * @brief gets the status
+ *
  * @param id
  * @param archived
  * @returns {Promise<CompanyEntity>}


### PR DESCRIPTION
## Archivar Cliente

[Archivar Cliente/56]: El admin es capaz de cambiar el status de 'archived'

### Descripción

Como administrador, quiero archivar los clientes que ya no tienen proyectos activos y poder des-archivarlos si es necesario.

### Cambios realizados

Se han cambiado un total de 5 archivos:
- admin.rounts
- admin.controller
- company.repository
- company.services
- company.services.test

Los cambios realizados son para poder archivar a los clientes, documentación e implementar pruebas.

### Story Points

5

### Pruebas

Se han realizado pruebas con Sinon.

### Criterios de aceptación

- [ ] Al acceder a la información de un cliente, el administrador utiliza  la opción de archivar el cliente.
- [ ] El sistema marca al cliente como archivado y ya no se mostrará mientras el filtro de “no archivado” esté activo.
- [ ] Los clientes archivados no serán visibles para los usuarios que NO sean admin.

### Dependencias

Ya cuando este PR este en Develop se debe de aceptar el PR del front. 

### Definición de Done

- [ ] El código ha sido revisado por al menos un miembro del equipo.
- [ ] Todas las pruebas pasan localmente.
- [ ] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [ ] La documentación ha sido actualizada (si corresponde).
- [ ] Cualquier nueva dependencia está documentada y justificada.
- [ ] Los cambios han sido probados en un entorno de preparación (si corresponde).

### Notas Adicionales

Ya es posible archivar y desarchivar a un cliente al cambiar el booleano a true o false.
