### PR TITLE
RF53: Poder marcar un proyecto como pagado

### DIFF
--- a/prisma/migrations/20240506205119_add_payed_status/migration.sql
+++ b/prisma/migrations/20240506205119_add_payed_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "project" ADD COLUMN     "payed" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,6 +210,7 @@ model project {
   total_hours   Decimal?  @db.Decimal(8, 2)
   periodicity   String?   @db.VarChar(256)
   is_chargeable Boolean?
+  payed         Boolean   @default(false)
   created_at    DateTime  @default(now()) @db.Timestamp(6)
   updated_at    DateTime? @updatedAt @db.Timestamp(6)
   id_company    String    @db.Uuid

--- a/src/core/app/interfaces/project.interface.ts
+++ b/src/core/app/interfaces/project.interface.ts
@@ -2,9 +2,9 @@ import { Decimal } from '@prisma/client/runtime/library';
 
 export interface UpdateProjectBody {
   id: string;
-  name: string;
-  idCompany: string;
-  category: string;
+  name?: string;
+  idCompany?: string;
+  category?: string;
   matter?: string | null;
   description?: string | null;
   startDate: Date;
@@ -14,6 +14,7 @@ export interface UpdateProjectBody {
   isChargeable?: boolean | null;
   status: string;
   totalHours?: Decimal | null;
+  payed?: boolean;
   createdAt: Date;
   updatedAt?: Date | null;
 }

--- a/src/core/app/services/project.service.ts
+++ b/src/core/app/services/project.service.ts
@@ -110,6 +110,7 @@ async function updateProject(body: UpdateProjectBody): Promise<ProjectEntity> {
     endDate: body.endDate ?? project.endDate,
     periodicity: body.periodicity ?? project.periodicity,
     area: body.area ?? project.area,
+    payed: body.payed,
     isChargeable: body.isChargeable ?? project.isChargeable,
     status: body.status ?? project.status,
     createdAt: project.createdAt,

--- a/src/core/domain/entities/project.entity.ts
+++ b/src/core/domain/entities/project.entity.ts
@@ -85,4 +85,8 @@ export interface ProjectEntity {
    * @param idCompany: string - Id for project company
    */
   idCompany: string;
+  /**
+   * @param payed: boolean - indicates if the project has been paid
+   */
+  payed?: boolean;
 }

--- a/src/core/infra/mappers/project-entity-from-db-model-mapper.ts
+++ b/src/core/infra/mappers/project-entity-from-db-model-mapper.ts
@@ -19,5 +19,6 @@ export function mapProjectEntityFromDbModel(model: project): ProjectEntity {
     createdAt: model.created_at,
     updatedAt: model.updated_at ? model.updated_at : undefined,
     idCompany: model.id_company,
+    payed: model.payed,
   };
 }

--- a/src/core/infra/repositories/project.repository.ts
+++ b/src/core/infra/repositories/project.repository.ts
@@ -138,6 +138,7 @@ async function updateProject(project: ProjectEntity): Promise<ProjectEntity> {
         is_chargeable: project.isChargeable,
         status: project.status,
         created_at: project.createdAt,
+        payed: project.payed,
       },
     });
     return mapProjectEntityFromDbModel(updatedProject);


### PR DESCRIPTION
## Pull Request Titulo

[RF53]: Poder marcar un proyecto como pagado

### Descripción

Se agregó soporte al esquema para soportar un booleano llamado "payed" para guardar si un proyecto está pagado o no.

### Cambios realizados

- Migración para agregar `payed`

### Story Points

5

### Pruebas

Este RF utiliza endpoints ya existentes y probados.

### Criterios de aceptación

- [ ] Al editar un proyecto y al crear un proyecto tengo la opción de seleccionar si el proyecto ya se pagó o sigue pendiente.
- [ ] El estatus de pagado o pendiente  se actualiza.
- [ ] Al ver la información de un proyecto, puede revisar el estatus de si ya se pagó o no está pagado

### Dependencias

Enumera cualquier dependencia o PR relacionado que deba fusionarse antes o después de este PR.

### Definición de Done

- [ ] El código ha sido revisado por al menos un miembro del equipo.
- [ ] Todas las pruebas pasan localmente.
- [ ] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [ ] La documentación ha sido actualizada (si corresponde).
- [ ] Cualquier nueva dependencia está documentada y justificada.
- [ ] Los cambios han sido probados en un entorno de preparación (si corresponde).
