### PR TITLE
Fix/rf16 project details

### DIFF
--- a/src/api/controllers/project.controller.ts
+++ b/src/api/controllers/project.controller.ts
@@ -126,4 +126,27 @@ async function getProjectById(req: Request, res: Response) {
   }
 }
 
-export const ProjectController = { getReportData, createProject, getAllProjects, getProjectsClient, getProjectById };
+/**
+ * A function that updates a project status
+ * @param req HTTP Request
+ * @param res Server response
+ */
+async function updateProjectStatus(req: Request, res: Response) {
+  try {
+    const { id } = idSchema.parse({ id: req.params.id });
+    const { status } = req.body;
+    await ProjectService.updateProjectStatus(id, status);
+    res.status(200).json({ message: 'Project status updated' });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+}
+
+export const ProjectController = {
+  getReportData,
+  createProject,
+  getAllProjects,
+  getProjectsClient,
+  getProjectById,
+  updateProjectStatus,
+};

--- a/src/api/routes/project.routes.ts
+++ b/src/api/routes/project.routes.ts
@@ -37,5 +37,10 @@ router.get(
   checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
   ProjectController.getProjectById
 );
+router.put(
+  '/details/:id',
+  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
+  ProjectController.updateProjectStatus
+);
 
 export { router as ProjectRouter };

--- a/src/core/app/services/__tests__/project.service.test.ts
+++ b/src/core/app/services/__tests__/project.service.test.ts
@@ -16,6 +16,7 @@ describe('ProjectService', () => {
   let findCompanyByIdStub: Sinon.SinonStub;
   let findProjectsByClientId: Sinon.SinonStub;
   let updateProjectStub: sinon.SinonStub;
+  let updateProjectStatusStub: sinon.SinonStub;
 
   beforeEach(() => {
     createProject = sinon.stub(ProjectRepository, 'createProject');
@@ -220,6 +221,29 @@ describe('ProjectService', () => {
       expect(res).to.deep.equal(mockProject.updatedProject);
     });
   });
+
+  describe('updateProjectStatus', () => {
+    const mockProject = prepareMockProject();
+
+    beforeEach(() => {
+      updateProjectStatusStub = sinon.stub(ProjectRepository, 'updateProjectStatus');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('Should update a project status', async () => {
+      findProjectByIdStub.resolves(mockProject.original);
+      updateProjectStatusStub.resolves(mockProject.updateProjectStatus);
+      const res = await ProjectService.updateProjectStatus(
+        mockProject.updateProjectStatus.id,
+        mockProject.updateProjectStatus.status
+      );
+
+      expect(res).to.equal(mockProject.updateProjectStatus.status);
+    });
+  });
 });
 
 function prepareMockProject() {
@@ -246,6 +270,12 @@ function prepareMockProject() {
     description: faker.lorem.words(12),
     matter: faker.lorem.word(),
   };
+
+  const updateProjectStatus = {
+    ...original,
+    status: faker.helpers.arrayElement(Object.values(ProjectStatus)),
+  };
+
   const updatePayload = {
     id: projectId,
     name: faker.lorem.words(2),
@@ -259,5 +289,5 @@ function prepareMockProject() {
     createdAt: faker.date.recent(),
     idCompany: companyId,
   };
-  return { original, updatedProject, updatePayload };
+  return { original, updatedProject, updateProjectStatus, updatePayload };
 }

--- a/src/core/app/services/project.service.ts
+++ b/src/core/app/services/project.service.ts
@@ -101,6 +101,7 @@ async function updateProjectStatus(projectId: string, newStatus: ProjectStatus):
     throw new Error('An unexpected error occured');
   }
 }
+
 export const ProjectService = {
   createProject,
   getAllProjects,

--- a/src/core/app/services/project.service.ts
+++ b/src/core/app/services/project.service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { ProjectStatus } from '../../../utils/enums';
 import { ProjectEntity } from '../../domain/entities/project.entity';
 import { ProjectRepository } from '../../infra/repositories/project.repository';
 
@@ -85,4 +86,25 @@ async function getProjectById(projectId: string): Promise<ProjectEntity> {
   }
 }
 
-export const ProjectService = { createProject, getAllProjects, findProjectsClient, getProjectById };
+/**
+ *
+ * @param projectId the id of the proyect to update its status
+ * @param newStatus the new status we are expecting
+ * @returns {Promise<ProjectStatus>} a promise that resolves the status update
+ * @throws {Error} if an unexpected error occurs
+ */
+async function updateProjectStatus(projectId: string, newStatus: ProjectStatus): Promise<ProjectStatus> {
+  try {
+    await ProjectRepository.updateProjectStatus(projectId, newStatus);
+    return newStatus;
+  } catch (error) {
+    throw new Error('An unexpected error occured');
+  }
+}
+export const ProjectService = {
+  createProject,
+  getAllProjects,
+  findProjectsClient,
+  getProjectById,
+  updateProjectStatus,
+};

--- a/src/core/infra/repositories/project.repository.ts
+++ b/src/core/infra/repositories/project.repository.ts
@@ -1,5 +1,6 @@
 import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '../../..';
+import { ProjectStatus } from '../../../utils/enums';
 import { ProjectEntity } from '../../domain/entities/project.entity';
 import { NotFoundError } from '../../errors/not-found.error';
 import { mapProjectEntityFromDbModel } from '../mappers/project-entity-from-db-model-mapper';
@@ -113,4 +114,29 @@ async function createProject(entity: ProjectEntity): Promise<ProjectEntity> {
   return mapProjectEntityFromDbModel(createData);
 }
 
-export const ProjectRepository = { findAll, findProjectStatusById, findById, findProjetsByClientId, createProject };
+/**
+ * A function that updates the project status into data base
+ * @param projectId ID of the project status to update
+ * @param newStatus New project status
+ * @returns {Promise<ProjectStatus>} the status updated
+ */
+async function updateProjectStatus(projectId: string, newStatus: ProjectStatus): Promise<ProjectStatus> {
+  try {
+    await Prisma.project.update({
+      where: { id: projectId },
+      data: { status: newStatus },
+    });
+    return newStatus;
+  } catch (error) {
+    throw new Error('Error updating project status');
+  }
+}
+
+export const ProjectRepository = {
+  findAll,
+  findProjectStatusById,
+  findById,
+  findProjetsByClientId,
+  createProject,
+  updateProjectStatus,
+};


### PR DESCRIPTION
## Fix RF/16 project details and status update

  [Fix]: Project details, agregar el update 

### Descripción

Agregar funcionalidad para cambiar el estatus de un proyecto de acuerdo a los valores ya definidos por ProjectStatus

### Cambios realizados

Todo de project:

- Rutas: Se agrega el put para /details/{:id}
- Controller: nueva funcion de updateProjectStatus
- Servicio: Se agrega updateProjectStatus que usa <ProjectStatus> ya que estan definidos los valores del status.
- Repository: updateProjectStatus donde de acuerdo al id, se hace el cambio a la bd del status

### Story Points

3

### Pruebas

Se tiene un proyecto original, al que se le hace un update de su estatus, se prueba que el update sea exitoso.
![image](https://github.com/Black-Dot-2024/Zeitgeist-Backend/assets/80787054/067aa1d9-17a3-4471-be04-e0b73f1f45bf)

### Criterios de aceptación

El update se hace de manera exitosa.

### Dependencias:
PR del front, ahí se encuentra un video que valida tanto front como backend.

[PR 135](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/pull/135)

### Definición de Done

- [ ] El código ha sido revisado por al menos un miembro del equipo.
- [ ] Todas las pruebas pasan localmente.
- [ ] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [ ] La documentación ha sido actualizada (si corresponde).
- [ ] Cualquier nueva dependencia está documentada y justificada.
- [ ] Los cambios han sido probados en un entorno de preparación (si corresponde).

