### PR TITLE
Fix RF03: Done status date

### DIFF
--- a/src/core/app/services/__tests__/task.services.test.ts
+++ b/src/core/app/services/__tests__/task.services.test.ts
@@ -25,6 +25,7 @@ describe('Task Service', () => {
   let validateEmployeeTaskStub: sinon.SinonStub;
   let updateTaskRepositoryStub: sinon.SinonStub;
   let updateTaskStatusRepositoryStub: sinon.SinonStub;
+  let updateTaskEndDateRepositoryStub: sinon.SinonStub;
 
   const idProject = 'fb6bde87-5890-4cf7-978b-8daa13f105f7';
 
@@ -64,6 +65,7 @@ describe('Task Service', () => {
     validateEmployeeTaskStub = sinon.stub(EmployeeTaskRepository, 'validateEmployeeTask');
     updateTaskRepositoryStub = sinon.stub(TaskRepository, 'updateTask');
     updateTaskStatusRepositoryStub = sinon.stub(TaskRepository, 'updateTaskStatus');
+    updateTaskEndDateRepositoryStub = sinon.stub(TaskRepository, 'updateTaskEndDate');
   });
 
   afterEach(() => {
@@ -365,6 +367,14 @@ describe('Task Service', () => {
     it('Should update a task status in the repository', async () => {
       findTaskByIdStub.resolves({ id: createdTask.id });
       updateTaskStatusRepositoryStub.resolves(true);
+      const result = await TaskService.updateTaskStatus(createdTask.id, TaskStatus.CANCELLED);
+      expect(result).to.be.true;
+    });
+
+    it('Should update the endDate to today when status is Done', async () => {
+      findTaskByIdStub.resolves({ id: createdTask.id });
+      updateTaskStatusRepositoryStub.resolves(true);
+      updateTaskEndDateRepositoryStub.resolves(true);
       const result = await TaskService.updateTaskStatus(createdTask.id, TaskStatus.DONE);
       expect(result).to.be.true;
     });

--- a/src/core/app/services/task.service.ts
+++ b/src/core/app/services/task.service.ts
@@ -236,8 +236,11 @@ async function updateTask(idTask: string, task: UpdatedTask): Promise<boolean> {
  */
 async function updateTaskStatus(idTask: string, status: TaskStatus): Promise<boolean> {
   try {
-    await TaskRepository.updateTaskStatus(idTask, status);
+    if (status === TaskStatus.DONE) {
+      await TaskRepository.updateTaskEndDate(idTask, new Date());
+    }
 
+    await TaskRepository.updateTaskStatus(idTask, status);
     return true;
   } catch (error: any) {
     throw new Error(error);

--- a/src/core/infra/repositories/tasks.repository.ts
+++ b/src/core/infra/repositories/tasks.repository.ts
@@ -233,6 +233,36 @@ async function updateTaskStatus(idTask: string, status: TaskStatus): Promise<boo
   }
 }
 
+/**
+ * @brief Updates the endDate of a task.
+ *
+ * @param task: UpdatedTask - Updated task.
+ * @returns {Promise<Boolean>} - True if the task was updated.
+ *
+ * @throws {Error} - If an error occurs when updating the task.
+ */
+async function updateTaskEndDate(idTask: string, endDate: Date): Promise<boolean> {
+  try {
+    const updatedTaskEndDate = await Prisma.task.update({
+      where: {
+        id: idTask,
+      },
+      data: {
+        end_date: endDate,
+        updated_at: new Date(),
+      },
+    });
+
+    if (!updatedTaskEndDate) {
+      throw new NotFoundError(RESOURCE_NAME);
+    }
+
+    return true;
+  } catch (error) {
+    throw new Error(`Failed to update task end date`);
+  }
+}
+
 export const TaskRepository = {
   findAll,
   createTask,
@@ -242,4 +272,5 @@ export const TaskRepository = {
   deleteTaskById,
   updateTask,
   updateTaskStatus,
+  updateTaskEndDate,
 };


### PR DESCRIPTION
## Fix RF03 Done status date

[Issue 173]: Actualización de empleado asignado a una tarea

### Descripción

Se arregló el siguiente [defecto](https://github.com/orgs/Black-Dot-2024/projects/5/views/1?pane=issue&itemId=62364628).

### Cambios realizados

- Si el estatus de la tarea actualizada es done el campo dueDate se actualiza a la fecha actual

