### PR TITLE
Mover Role Check al principio del router

### DIFF
--- a/src/api/routes/admin.routes.ts
+++ b/src/api/routes/admin.routes.ts
@@ -5,8 +5,9 @@ import { checkAuthRole } from '../middlewares/rbac.middleware';
 
 const router = Router();
 
-router.get('/roles', checkAuthRole([SupportedRoles.ADMIN]), getAllRoles);
-router.put('/role', checkAuthRole([SupportedRoles.ADMIN]), updateUserRole);
-router.put('/archive/:id', checkAuthRole([SupportedRoles.ADMIN]), archiveClient);
+router.use(checkAuthRole([SupportedRoles.ADMIN]));
+router.get('/roles', getAllRoles);
+router.put('/role', updateUserRole);
+router.put('/archive/:id', archiveClient);
 
 export { router as AdminRouter };

--- a/src/api/routes/company.routes.ts
+++ b/src/api/routes/company.routes.ts
@@ -6,26 +6,10 @@ import { checkAuthRole } from '../middlewares/rbac.middleware';
 
 const router = Router();
 
-router.get(
-  '/',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  CompanyController.getAll
-);
-router.get(
-  '/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  CompanyController.getUnique
-);
-router.post(
-  '/new',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  CompanyController.create
-);
-router.put(
-  '/:id',
-  checkAuthToken,
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  CompanyController.updateClient
-);
+router.use(checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]));
+router.get('/', CompanyController.getAll);
+router.get('/:id', CompanyController.getUnique);
+router.post('/new', CompanyController.create);
+router.put('/:id', checkAuthToken, CompanyController.updateClient);
 
 export { router as CompanyRouter };

--- a/src/api/routes/employee.routes.ts
+++ b/src/api/routes/employee.routes.ts
@@ -5,9 +5,11 @@ import { checkAuthRole } from '../middlewares/rbac.middleware';
 
 const router = Router();
 
-router.get('/', checkAuthRole([SupportedRoles.ADMIN]), EmployeeController.getAllEmployees);
-router.get('/getAllEmployees', checkAuthRole([SupportedRoles.ADMIN]), EmployeeController.getAllEmployees);
 router.post('/signup', EmployeeController.userExists);
-router.delete('/delete/:id', checkAuthRole([SupportedRoles.ADMIN]), EmployeeController.deleteEmployee);
+
+router.use(checkAuthRole([SupportedRoles.ADMIN]));
+router.get('/', EmployeeController.getAllEmployees);
+router.get('/getAllEmployees', EmployeeController.getAllEmployees);
+router.delete('/delete/:id', EmployeeController.deleteEmployee);
 
 export { router as EmployeeRouter };

--- a/src/api/routes/project.routes.ts
+++ b/src/api/routes/project.routes.ts
@@ -5,40 +5,13 @@ import { checkAuthRole } from '../middlewares/rbac.middleware';
 
 const router = Router();
 
-router.get(
-  '/',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  ProjectController.getDepartmentProjects
-);
-router.get(
-  '/details/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  ProjectController.getProjectById
-);
-router.get(
-  '/report/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  ProjectController.getReportData
-);
-router.get(
-  '/:clientId',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  ProjectController.getProjectsClient
-);
-router.post(
-  '/create',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  ProjectController.createProject
-);
-router.put(
-  '/edit/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  ProjectController.updateProject
-);
-router.put(
-  '/details/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  ProjectController.updateProjectStatus
-);
+router.use(checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]));
+router.get('/', ProjectController.getDepartmentProjects);
+router.get('/details/:id', ProjectController.getProjectById);
+router.get('/report/:id', ProjectController.getReportData);
+router.get('/:clientId', ProjectController.getProjectsClient);
+router.post('/create', ProjectController.createProject);
+router.put('/edit/:id', ProjectController.updateProject);
+router.put('/details/:id', ProjectController.updateProjectStatus);
 
 export { router as ProjectRouter };

--- a/src/api/routes/task.routes.ts
+++ b/src/api/routes/task.routes.ts
@@ -5,40 +5,13 @@ import { checkAuthRole } from '../middlewares/rbac.middleware';
 
 const router = Router();
 
-router.get(
-  '/project/:idProject',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  TaskController.getTasksFromProject
-);
-router.get(
-  '/employee/:idEmployee',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  TaskController.findTasksByEmployeeId
-);
-router.get(
-  '/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  TaskController.findTaskById
-);
-router.post(
-  '/create',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  TaskController.createTask
-);
-router.put(
-  '/update/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  TaskController.updateTask
-);
-router.put(
-  '/update/status/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  TaskController.updateTaskStatus
-);
-router.delete(
-  '/delete/:id',
-  checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]),
-  TaskController.deleteTask
-);
+router.use(checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]));
+router.get('/project/:idProject', TaskController.getTasksFromProject);
+router.get('/employee/:idEmployee', TaskController.findTasksByEmployeeId);
+router.get('/:id', TaskController.findTaskById);
+router.post('/create', TaskController.createTask);
+router.put('/update/:id', TaskController.updateTask);
+router.put('/update/status/:id', TaskController.updateTaskStatus);
+router.delete('/delete/:id', TaskController.deleteTask);
 
 export { router as TaskRouter };


### PR DESCRIPTION
## Mover Role Check al principio del router

Mover Role Check al principio del router

### Descripción

Se mueve el role check al principio del router para reducir las líneas de código

### Cambios realizados

- Todos los routers fueron cambiados