### PR TITLE
Fix/zod validations

### DIFF
--- a/src/api/controllers/company.controller.ts
+++ b/src/api/controllers/company.controller.ts
@@ -59,7 +59,7 @@ async function updateClient(req: Request, res: Response) {
  * @param res
  */
 
-async function getAll(req: Request, res: Response) {
+async function getAll(_: Request, res: Response) {
   try {
     const data = await CompanyService.findAll();
     res.status(200).json(data);

--- a/src/api/controllers/notification.controller.ts
+++ b/src/api/controllers/notification.controller.ts
@@ -19,15 +19,21 @@ const userToken = z.object({
 /**
  * @brief Schema for notification
  *
+ * @param id: string - Id of notification
  * @param title: string - Title of notification
  * @param body: string - Body of notification
+ * @param createdAt: Date - Date of creation of notification
+ * @param updatedAt: Date - Most recent date of update of notification
  *
  * @return {z.ZodObject} - The schema for notification
  */
 
 const notificationSchema = z.object({
+  id: z.string(),
   title: z.string(),
-  body: z.string()
+  body: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date().nullable()
 });
 
 /**
@@ -67,6 +73,7 @@ async function saveToken(req: Request, res: Response) {
 
 async function createNotification(req: Request, res: Response) {
   try {
+    notificationSchema.parse(req.body);
     const data = await NotificationService.createNotification(req.body);
     res.status(201).json({ data });
   } catch (error: any) {

--- a/src/api/controllers/notification.controller.ts
+++ b/src/api/controllers/notification.controller.ts
@@ -33,7 +33,7 @@ const notificationSchema = z.object({
   title: z.string(),
   body: z.string(),
   createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date().nullable()
+  updatedAt: z.coerce.date().optional()
 });
 
 /**

--- a/src/api/controllers/notification.controller.ts
+++ b/src/api/controllers/notification.controller.ts
@@ -19,7 +19,7 @@ const userToken = z.object({
 /**
  * @brief Schema for notification
  *
- * @param id: string - Id of notification
+ * @param id: uuid - Id of notification
  * @param title: string - Title of notification
  * @param body: string - Body of notification
  * @param createdAt: Date - Date of creation of notification
@@ -29,7 +29,7 @@ const userToken = z.object({
  */
 
 const notificationSchema = z.object({
-  id: z.string(),
+  id: z.string().uuid(),
   title: z.string(),
   body: z.string(),
   createdAt: z.coerce.date(),

--- a/src/api/controllers/notification.controller.ts
+++ b/src/api/controllers/notification.controller.ts
@@ -25,7 +25,7 @@ const userToken = z.object({
  * @return {z.ZodObject} - The schema for notification
  */
 
-const notificacionSchema = z.object({
+const notificationSchema = z.object({
   title: z.string(),
   body: z.string()
 });

--- a/src/api/controllers/notification.controller.ts
+++ b/src/api/controllers/notification.controller.ts
@@ -17,6 +17,20 @@ const userToken = z.object({
 });
 
 /**
+ * @brief Schema for notification
+ *
+ * @param title: string - Title of notification
+ * @param body: string - Body of notification
+ *
+ * @return {z.ZodObject} - The schema for notification
+ */
+
+const notificacionSchema = z.object({
+  title: z.string(),
+  body: z.string()
+});
+
+/**
  * @brief Function that calls the service to save the token of the employee
  *
  * @param req: Request
@@ -71,7 +85,7 @@ async function createNotification(req: Request, res: Response) {
  * @throws {Error} If an unexpected error occurs
  */
 
-async function getAllNotifications(req: Request, res: Response) {
+async function getAllNotifications(_: Request, res: Response) {
   try {
     const data = await NotificationService.getAllNotifications();
     res.status(200).json({ data });

--- a/src/api/controllers/project.controller.ts
+++ b/src/api/controllers/project.controller.ts
@@ -140,6 +140,7 @@ async function getProjectById(req: Request, res: Response) {
  */
 async function updateProject(req: Request, res: Response) {
   try {
+    createProjectRequestSchema.parse(req.body);
     const projectData = req.body;
     const updatedProject = await ProjectService.updateProject({ ...projectData, id: req.params.id });
     res.status(200).json({ data: updatedProject });

--- a/src/api/controllers/project.controller.ts
+++ b/src/api/controllers/project.controller.ts
@@ -4,16 +4,6 @@ import { ProjectReportService } from '../../core/app/services/project-report.ser
 import { ProjectService } from '../../core/app/services/project.service';
 import { ProjectCategory, ProjectPeriodicity, ProjectStatus, SupportedDepartments } from '../../utils/enums';
 
-/**
- * @description Validates that a start date should be before than an end date
- * @param {Date} start Start date
- * @param {Date} end End date
- * @returns {boolean} If dates are valid
- */
-const areDatesValid = (start: Date, end: Date): boolean => {
-  return new Date(start).getTime() <= new Date(end).getTime();
-}
-
 const idSchema = z.object({
   id: z.string().uuid(),
 });

--- a/src/api/controllers/project.controller.ts
+++ b/src/api/controllers/project.controller.ts
@@ -18,7 +18,7 @@ const createProjectRequestSchema = z.object({
   startDate: z.coerce.date(),
   endDate: z.coerce.date().nullable(),
   periodicity: z.nativeEnum(ProjectPeriodicity),
-  isChargeable: z.boolean(),
+  isChargeable: z.boolean().nullable(),
   area: z.nativeEnum(SupportedDepartments),
 });
 
@@ -43,7 +43,7 @@ async function createProject(req: Request, res: Response) {
       category: data.category,
       endDate: data.endDate || null,
       idCompany: data.idCompany,
-      isChargeable: data.isChargeable,
+      isChargeable: data.isChargeable || false,
       periodicity: data.periodicity,
       startDate: data.startDate,
     });

--- a/src/api/controllers/project.controller.ts
+++ b/src/api/controllers/project.controller.ts
@@ -9,11 +9,26 @@ const idSchema = z.object({
 });
 
 const createProjectRequestSchema = z.object({
-  name: z.string(),
+  name: z
+    .string()
+    .min(1, {
+      message: 'Title must have at least 1 character',
+    })
+    .max(70, {
+      message: 'Title must have at most 70 characters',
+    }),
   idCompany: z.string().uuid({ message: 'Please provide valid UUID' }),
   category: z.nativeEnum(ProjectCategory),
   matter: z.string().optional(),
-  description: z.string().optional(),
+  description: z
+    .string()
+    .min(1, {
+      message: 'Description must have at least 1 character',
+    })
+    .max(256, {
+      message: 'Description must have at most 255 characters',
+    })
+    .optional(),
   status: z.nativeEnum(ProjectStatus),
   startDate: z.coerce.date(),
   endDate: z.coerce.date().nullable(),

--- a/src/api/controllers/project.controller.ts
+++ b/src/api/controllers/project.controller.ts
@@ -4,6 +4,16 @@ import { ProjectReportService } from '../../core/app/services/project-report.ser
 import { ProjectService } from '../../core/app/services/project.service';
 import { ProjectCategory, ProjectPeriodicity, ProjectStatus, SupportedDepartments } from '../../utils/enums';
 
+/**
+ * @description Validates that a start date should be before than an end date
+ * @param {Date} start Start date
+ * @param {Date} end End date
+ * @returns {boolean} If dates are valid
+ */
+const areDatesValid = (start: Date, end: Date): boolean => {
+  return new Date(start).getTime() <= new Date(end).getTime();
+}
+
 const idSchema = z.object({
   id: z.string().uuid(),
 });

--- a/src/api/controllers/task.controller.ts
+++ b/src/api/controllers/task.controller.ts
@@ -228,7 +228,6 @@ async function updateTask(req: Request, res: Response) {
     const idTask = req.params.id;
 
     const validatedTaskData = validateUpdatedTaskData(idTask, req.body);
-    console.log(validatedTaskData);
     const data = await TaskService.updateTask(idTask, {
       ...validatedTaskData,
       idEmployee: validatedTaskData.idEmployee,

--- a/src/api/controllers/task.controller.ts
+++ b/src/api/controllers/task.controller.ts
@@ -30,7 +30,7 @@ const taskSchema = z.object({
       message: 'Description must have at least 1 character',
     })
     .max(256, {
-      message: 'Description must have at most 256 characters',
+      message: 'Description must have at most 255 characters',
     }),
   status: taskStatusSchema,
   startDate: z.coerce.date({ required_error: 'Start date is required' }),

--- a/src/core/app/services/task.service.ts
+++ b/src/core/app/services/task.service.ts
@@ -266,6 +266,22 @@ async function updateTask(idTask: string, task: UpdatedTask): Promise<boolean> {
       task.endDate = new Date();
     }
 
+    if (
+      task.startDate !== null &&
+      task.endDate !== null &&
+      task.startDate !== undefined &&
+      task.endDate !== undefined &&
+      !areDatesValid(task.startDate, task.endDate)
+    ) {
+      throw new Error('Start date must be before end date');
+    }
+    if (task.workedHours !== undefined && task.workedHours < 0) {
+      throw new Error('Worked hours must be greater than or equal to 0');
+    }
+    if (task.workedHours !== undefined && task.workedHours > 1000) {
+      throw new Error('Worked hours must be lower than or equal to 1000');
+    }
+
     if (task.idEmployee) {
       const employee = await EmployeeRepository.findById(task.idEmployee);
       if (!employee) {

--- a/src/core/app/services/task.service.ts
+++ b/src/core/app/services/task.service.ts
@@ -11,6 +11,16 @@ import { TaskRepository } from '../../infra/repositories/tasks.repository';
 import { TaskDetail } from '../interfaces/task.interface';
 
 /**
+ * @description Validates that a start date should be before than an end date
+ * @param {Date} start Start date
+ * @param {Date} end End date
+ * @returns {boolean} If dates are valid
+ */
+const areDatesValid = (start: Date, end: Date): boolean => {
+  return new Date(start).getTime() <= new Date(end).getTime();
+}
+
+/**
  * Gets all tasks from a unique project using the repository.
  *
  * @param projectId: string - projectId to which the tasks are related.

--- a/src/core/app/services/task.service.ts
+++ b/src/core/app/services/task.service.ts
@@ -109,6 +109,16 @@ async function createTask(newTask: BareboneTask): Promise<Task | null> {
       idProject: newTask.idProject,
     };
 
+    if (task.endDate !== null && task.endDate !== undefined && !areDatesValid(task.startDate, task.endDate)) {
+      throw new Error('Start date must be before end date');
+    }
+    if (task.workedHours !== undefined && task.workedHours < 0) {
+      throw new Error('Worked hours must be greater than or equal to 0');
+    }
+    if (task.workedHours !== undefined && task.workedHours > 1000) {
+      throw new Error('Worked hours must be lower than or equal to 1000');
+    }
+
     const createdTask = await TaskRepository.createTask(task);
     if (!createdTask) {
       throw new Error('Task already exists');


### PR DESCRIPTION
## Fix-Zod validations across multiple services

### Descripción

Se testearon los endpoints de `POST`y `PUT` para validar los datos de entrada con zod y con lógica (por ejemplo en las fechas, etc).

### Cambios realizados

- Se añadieron más parámetros en el `createProjectRequestSchema` para que concordara con las restricciones del frontend.
- Se añadió el uso del `createProjectRequestSchema` en el endpoint de `updateProject()`.
- Se añadió lógica en la capa de servicios en los proyectos y tareas para validar si las fechas tenían sentido.
- Se añadió la misma validación en la capa de servicios de las tareas de las horas trabajadas tal cual está en el frontend.

### Pruebas

Las pruebas se hicieron usando Postman (Se adjunto JSON).

### Screen de pruebas y/o notas

Cualquier información:

- Les dejo el JSON del Postman que utilicé:
[Zeigeist.postman_collection.json](https://github.com/Black-Dot-2024/Zeitgeist-Backend/files/15434192/Zeigeist.postman_collection.json)

> Para actualizar el token solo edítenlo aquí:
<img width="623" alt="Captura de Pantalla 2024-05-24 a la(s) 6 23 40" src="https://github.com/Black-Dot-2024/Zeitgeist-Backend/assets/59104775/7b05f512-2ffa-40c5-ae23-be6e5798c951">

- Los endpoints:
<img width="379" alt="Captura de Pantalla 2024-05-24 a la(s) 6 23 11" src="https://github.com/Black-Dot-2024/Zeitgeist-Backend/assets/59104775/186890ec-dadf-4ee3-a09f-c57f828a7cec">
