### PR TITLE
Feat/Expenses/RF32: Endpoint for expenseReport data by id

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["omitApi"]
 }
 
 datasource db {
@@ -97,6 +98,7 @@ model expense {
   id             String         @id @db.Uuid
   title          String         @db.VarChar(70)
   justification  String         @db.VarChar(255)
+  supplier       String?        @db.VarChar(70)
   total_amount   Decimal        @db.Decimal(18, 2)
   status         String?        @db.VarChar(256)
   category       String?        @db.VarChar(70)
@@ -104,33 +106,23 @@ model expense {
   created_at     DateTime       @default(now()) @db.Timestamp(6)
   updated_at     DateTime?      @updatedAt @db.Timestamp(6)
   id_report      String         @db.Uuid
-  id_file        String?        @db.Uuid
-  file           file?          @relation(fields: [id_file], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  url_file       String?        @db.VarChar(512)
   expense_report expense_report @relation(fields: [id_report], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }
 
 model expense_report {
   id           String    @id @db.Uuid
+  title        String    @db.VarChar(70)
   description  String    @db.VarChar(255)
   start_date   DateTime  @db.Date
   end_date     DateTime? @db.Date
   status       String?   @db.VarChar(256)
-  total_amount Decimal?  @db.Decimal(8, 2)
   created_at   DateTime  @default(now()) @db.Timestamp(6)
   updated_at   DateTime? @updatedAt @db.Timestamp(6)
   id_employee  String    @db.Uuid
+  url_voucher  String?   @db.VarChar(512)
   expense      expense[]
   employee     employee  @relation(fields: [id_employee], references: [id], onDelete: NoAction, onUpdate: NoAction)
-}
-
-model file {
-  id          String    @id @db.Uuid
-  description String?   @db.VarChar(256)
-  format      String    @default(".zip") @db.VarChar(256)
-  url         String    @unique @db.VarChar(256)
-  created_at  DateTime  @default(now()) @db.Timestamp(6)
-  updated_at  DateTime? @updatedAt @db.Timestamp(6)
-  expense     expense[]
 }
 
 model form {

--- a/src/api/controllers/expense.controller.ts
+++ b/src/api/controllers/expense.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { ExpenseService } from '../../core/app/services/expense.service';
+
+const idSchema = z.object({
+  id: z.string().uuid(),
+});
+
+/**
+ * A function that handles the request to obtain expense report details by its id
+ * @param req HTTP Request
+ * @param res Server response
+ */
+async function getReportById(req: Request, res: Response) {
+  try {
+    const { id } = idSchema.parse({ id: req.params.id });
+    const expenseDetails = await ExpenseService.getReportById(id, req.body.auth.email);
+    if (expenseDetails) {
+      res.status(200).json(expenseDetails);
+    }
+  } catch (error: any) {
+    if (error.message === 'Unauthorized employee') {
+      res.status(403).json({ message: error.message });
+    } else {
+      res.status(500).json({ message: error.message });
+    }
+  }
+}
+
+export const ExpenseController = { getReportById };

--- a/src/api/routes/expense.routes.ts
+++ b/src/api/routes/expense.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { SupportedRoles } from '../../utils/enums';
+import { ExpenseController } from '../controllers/expense.controller';
+import { checkAuthRole } from '../middlewares/rbac.middleware';
+
+const router = Router();
+
+router.use(checkAuthRole([SupportedRoles.ACCOUNTING, SupportedRoles.LEGAL, SupportedRoles.ADMIN]));
+router.get('/report/:id', ExpenseController.getReportById);
+
+export { router as ExpenseRouter };

--- a/src/api/routes/index.routes.ts
+++ b/src/api/routes/index.routes.ts
@@ -4,6 +4,7 @@ import { AdminRouter } from './admin.routes';
 import { CompanyRouter } from './company.routes';
 import { DepartmentRouter } from './department.routes';
 import { EmployeeRouter } from './employee.routes';
+import { ExpenseRouter } from './expense.routes';
 import { HomeRouter } from './home.routes';
 import { NotificationRouter } from './notification.routes';
 import { ProjectRouter } from './project.routes';
@@ -38,6 +39,9 @@ baseRouter.use(`${V1_PATH}/company`, CompanyRouter);
 
 // Notification
 baseRouter.use(`${V1_PATH}/notification`, NotificationRouter);
+
+// Expense
+baseRouter.use(`${V1_PATH}/expense`, ExpenseRouter);
 
 // Health check
 baseRouter.use(`${V1_PATH}/health`, (_req, res) => res.send('OK'));

--- a/src/core/app/services/__tests__/expense.service.test.ts
+++ b/src/core/app/services/__tests__/expense.service.test.ts
@@ -1,0 +1,77 @@
+import { faker } from '@faker-js/faker';
+import { expect } from 'chai';
+import { randomUUID } from 'crypto';
+import { default as Sinon, default as sinon } from 'sinon';
+import { ExpenseReportStatus, SupportedRoles } from '../../../../utils/enums';
+
+import { EmployeeRepository } from '../../../infra/repositories/employee.repository';
+import { ExpenseRepository } from '../../../infra/repositories/expense.repository';
+import { RoleRepository } from '../../../infra/repositories/role.repository';
+import { ExpenseService } from '../expense.service';
+
+describe('ExpenseService', () => {
+  let findEmployeeByEmailStub: Sinon.SinonStub;
+  let findRoleByEmailStub: Sinon.SinonStub;
+  let findExpenseByIdStub: Sinon.SinonStub;
+
+  beforeEach(() => {
+    findEmployeeByEmailStub = sinon.stub(EmployeeRepository, 'findByEmail');
+    findRoleByEmailStub = sinon.stub(RoleRepository, 'findByEmail');
+    findExpenseByIdStub = sinon.stub(ExpenseRepository, 'findById');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getReportById', () => {
+    it('Should return the expense report details', async () => {
+      const reportId = randomUUID();
+      const userEmail = faker.internet.email();
+      const userId = randomUUID();
+
+      const employee = {
+        id: userId,
+        email: userEmail,
+        name: faker.lorem.words(2),
+        role: SupportedRoles.ADMIN,
+      };
+      const role = {
+        title: SupportedRoles.ADMIN,
+      };
+      const expenses = [
+        {
+          id: randomUUID(),
+          title: faker.lorem.words(3),
+          justification: faker.lorem.words(10),
+          totalAmount: faker.number.float(),
+          date: new Date(),
+          createdAt: new Date(),
+          idReport: reportId,
+        },
+      ];
+      const existingReport = {
+        id: reportId,
+        title: faker.lorem.words(3),
+        description: faker.lorem.words(10),
+        startDate: new Date(),
+        endDate: new Date(),
+        status: ExpenseReportStatus.PENDING,
+        createdAt: new Date(),
+        idEmployee: userId,
+        expenses: expenses,
+      };
+
+      findEmployeeByEmailStub.resolves(employee);
+      findRoleByEmailStub.resolves(role);
+      findExpenseByIdStub.resolves(existingReport);
+
+      const res = await ExpenseService.getReportById(reportId, userEmail);
+
+      expect(res).to.exist;
+      expect(res).to.be.equal(existingReport);
+      expect(res.id).to.equal(reportId);
+      expect(res.expenses?.length).to.equal(expenses.length);
+    });
+  });
+});

--- a/src/core/app/services/expense.service.ts
+++ b/src/core/app/services/expense.service.ts
@@ -1,0 +1,45 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { SupportedRoles } from '../../../utils/enums';
+import { ExpenseReport } from '../../domain/entities/expense.entity';
+import { EmployeeRepository } from '../../infra/repositories/employee.repository';
+import { ExpenseRepository } from '../../infra/repositories/expense.repository';
+import { RoleRepository } from '../../infra/repositories/role.repository';
+
+/**
+ *
+ * @param getReportById the id of the expense report we want the details
+ * @param email the email of the user
+ * @returns {Promise<ExpenseReport>} a promise that resolves the details of the expense report
+ * @throws {Error} if an unexpected error occurs
+ */
+
+async function getReportById(reportId: string, email: string): Promise<ExpenseReport> {
+  try {
+    const [employee, role, expenseReport] = await Promise.all([
+      EmployeeRepository.findByEmail(email),
+      RoleRepository.findByEmail(email),
+      ExpenseRepository.findById(reportId),
+    ]);
+
+    if (role.title.toUpperCase() != SupportedRoles.ADMIN.toUpperCase() && expenseReport.idEmployee != employee?.id) {
+      throw new Error('Unauthorized employee');
+    }
+
+    let totalAmount = new Decimal(0);
+    if (expenseReport.expenses) {
+      expenseReport.expenses.forEach(expense => {
+        totalAmount = totalAmount.add(expense.totalAmount);
+      });
+    }
+    expenseReport.totalAmount = totalAmount;
+
+    return expenseReport;
+  } catch (error: any) {
+    if (error.message === 'Unauthorized employee') {
+      throw error;
+    }
+    throw new Error('An unexpected error occured');
+  }
+}
+
+export const ExpenseService = { getReportById };

--- a/src/core/domain/entities/expense.entity.ts
+++ b/src/core/domain/entities/expense.entity.ts
@@ -1,0 +1,230 @@
+import { employee, expense } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+
+/**
+ * @brief This class is used to define the structure of the Expense entity
+ *
+ * @param id: string - Unique identifier of the expense
+ * @param title: string - Expense title
+ * @param justification: string - Expense justification
+ ~ @param supplier: string - Expense supplier
+ * @param totalAmount: Decimal - Expense amount
+ + @param status?: string - Expense status (optional)
+ * @param category?: string - Expense category (optional)
+ * @param date: Date - Expense date
+ * @param createdAt: Date - Expense creation date
+ * @param updatedAt?: Date - Expense update date (optional)
+ * @param idReport: string - Unique identifier of expense report associated
+ * @param urlFile?: string - URL of the file associated with the expense (optional)
+ *
+ * @return void
+ *
+ * @description The structure is based on the MER, and there's the idea of using custom data types, like UUID.
+ */
+
+export interface ExpenseEntity {
+  /**
+   * @param id: string - Expense id
+   */
+  id: string;
+  /**
+   * @param title: string - Expense title
+   */
+  title: string;
+  /**
+   * @param justification: string - Expense justification
+   */
+  justification: string;
+  /**
+   * @param supplier: string - Expense supplier
+   */
+  supplier: string;
+  /**
+   * @param totalAmount: Decimal - Expense amount
+   */
+  totalAmount: Decimal;
+  /**
+   * @param status: string - Expense status
+   */
+  status?: string | null;
+  /**
+   * @param category: string - Expense category (optional)
+   */
+  category?: string | null;
+  /**
+   * @param date: Date - Expense date
+   */
+  date: Date;
+  /**
+   * @param createdAt: Date - Expense creation date
+   */
+  createdAt: Date;
+  /**
+   * @param updatedAt: Date - Expense update date (optional)
+   */
+  updatedAt?: Date | null;
+  /**
+   * @param idReport: string - Expense report id
+   */
+  idReport: string;
+  /**
+   * @param urlFile: string - URL of the file associated with the expense (optional)
+   */
+  urlFile?: string | null;
+}
+
+/**
+ * @brief This class is used to define the structure of the Expense Report entity
+ *
+ * @param id: string - Unique identifier of the expense report
+ * @param title: string - Expense Report title
+ * @param description: string - Expense Report description
+ * @param startDate: Date - Expense Report start date
+ * @param endDate?: Date - Expense Report end date (optional)
+ + @param status?: string - Expense Report status (optional)
+ * @param createdAt?: Date - Expense Report creation date (optional)
+ * @param updatedAt?: Date - Expense Report update date (optional)
+ * @param url_voucher?: string - URL of the voucher associated with the expense report (optional)
+ * @param idEmployee: string - Unique identifier of the employee associated
+ * @param employeeFirstName?: string - Employee first name (optional)
+ * @param employeeLastName?: string - Employee last name (optional)
+ * @param expenses?: ExpenseEntity[] - Array of expenses associated with the report (optional)
+ * @param totalAmount?: Decimal - Total amount of the expenses associated with the report (optional)
+ *
+ * @return void
+ *
+ * @description The structure is based on the MER, and there's the idea of using custom data types, like UUID.
+ */
+
+export interface ExpenseReport {
+  /**
+   * @param id: string - Expense report id
+   */
+  id: string;
+  /**
+   * @param title: string - Expense report title
+   */
+  title: string;
+  /**
+   * @param description: string - Expense report description
+   */
+  description: string;
+  /**
+   * @param startDate: Date - Expense report start date
+   */
+  startDate: Date;
+  /**
+   * @param endDate: Date - Expense report end date
+   */
+  endDate?: Date | null;
+  /**
+   * @param status: string - Expense report status
+   */
+  status?: string | null;
+  /**
+   * @param createdAt: Date - Expense report creation date
+   */
+  createdAt?: Date | null;
+  /**
+   * @param updatedAt: Date - Expense report update date
+   */
+  updatedAt?: Date | null;
+  /**
+   * @param urlVoucher: string - URL of the voucher associated with the expense report
+   */
+  urlVoucher?: string | null;
+  /**
+   * @param idEmployee: string - Employee id
+   */
+  idEmployee: string;
+  /**
+   * @param employeeFirstName: string - Employee first name
+   */
+  employeeFirstName?: string;
+  /**
+   * @param employeeLastName: string - Employee last name
+   */
+  employeeLastName?: string;
+  /**
+   * @param expenses: ExpenseEntity[] - Array of expenses associated with the report
+   */
+  expenses?: ExpenseEntity[];
+
+  /**
+   * @param totalAmount: Decimal - Total amount of the expenses associated with the report
+   */
+  totalAmount?: Decimal;
+}
+
+/**
+ * @brief This class is used to define the structure of the Expense Report Raw Data from the db.
+ *
+ * @param id: string - Unique identifier of the expense report
+ * @param title: string - Expense Report title
+ * @param description: string - Expense Report description
+ * @param start_date: Date - Expense Report start date
+ * @param end_date?: Date - Expense Report end date (optional)
+ + @param status?: string - Expense Report status (optional)
+ * @param createdAt: Date - Expense Report creation date
+ * @param updatedAt?: Date - Expense Report update date (optional)
+ * @param url_voucher?: string - URL of the voucher associated with the expense report (optional)
+ * @param id_employee: string - Unique identifier of the employee associated
+ * @param employee?: employee - Employee information associated with the report (optional)
+ * @param expense?: expense[] - Array of expenses associated with the report (optional)
+ * @param totalAmount?: Decimal - Total amount of the expenses associated with the report (optional)
+ *
+ * @return void
+ *
+ * @description The structure is based on the MER, and there's the idea of using custom data types, like UUID.
+ */
+
+export interface RawExpenseReport {
+  /**
+   * @param id: string - Expense report id
+   */
+  id: string;
+  /**
+   * @param title: string - Expense report title
+   */
+  title: string;
+  /**
+   * @param description: string - Expense report description
+   */
+  description: string;
+  /**
+   * @param startDate: Date - Expense report start date
+   */
+  start_date: Date;
+  /**
+   * @param endDate: Date - Expense report end date
+   */
+  end_date?: Date | null;
+  /**
+   * @param status: string - Expense report status
+   */
+  status?: string | null;
+  /**
+   * @param createdAt: Date - Expense report creation date
+   */
+  createdAt?: Date | null;
+  /**
+   * @param updatedAt: Date - Expense report update date
+   */
+  updatedAt?: Date | null;
+  /**
+   * @param url_voucher: string - URL of the voucher associated with the expense report
+   */
+  url_voucher?: string | null;
+  /**
+   * @param idEmployee: string - Employee id
+   */
+  id_employee: string;
+  /**
+   * @param employee: employee - Employee information associated with the report
+   */
+  employee?: employee | null;
+  /**
+   * @param expense: expense[] - Array of expenses associated with the report
+   */
+  expense?: expense[] | null;
+}

--- a/src/core/domain/entities/expense.entity.ts
+++ b/src/core/domain/entities/expense.entity.ts
@@ -1,5 +1,6 @@
 import { employee, expense } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
+import { ExpenseReportStatus } from '../../../utils/enums/index';
 
 /**
  * @brief This class is used to define the structure of the Expense entity
@@ -120,7 +121,7 @@ export interface ExpenseReport {
   /**
    * @param status: string - Expense report status
    */
-  status?: string | null;
+  status?: ExpenseReportStatus | null;
   /**
    * @param createdAt: Date - Expense report creation date
    */

--- a/src/core/domain/entities/expense.entity.ts
+++ b/src/core/domain/entities/expense.entity.ts
@@ -82,7 +82,7 @@ export interface ExpenseEntity {
  * @param description: string - Expense Report description
  * @param startDate: Date - Expense Report start date
  * @param endDate?: Date - Expense Report end date (optional)
- + @param status?: string - Expense Report status (optional)
+ + @param status?: ExpenseReportStatus - Expense Report status (optional)
  * @param createdAt?: Date - Expense Report creation date (optional)
  * @param updatedAt?: Date - Expense Report update date (optional)
  * @param url_voucher?: string - URL of the voucher associated with the expense report (optional)
@@ -119,7 +119,7 @@ export interface ExpenseReport {
    */
   endDate?: Date | null;
   /**
-   * @param status: string - Expense report status
+   * @param status: ExpenseReportStatus - Expense report status
    */
   status?: ExpenseReportStatus | null;
   /**

--- a/src/core/infra/mappers/expense-entity-from-db-model.mapper.ts
+++ b/src/core/infra/mappers/expense-entity-from-db-model.mapper.ts
@@ -1,0 +1,35 @@
+import { expense } from '@prisma/client';
+import { ExpenseEntity, ExpenseReport, RawExpenseReport } from '../../domain/entities/expense.entity';
+
+export function mapExpenseEntityFromDbModel(model: expense): ExpenseEntity {
+  return {
+    id: model.id,
+    title: model.title,
+    justification: model.justification,
+    supplier: model.supplier ? model.supplier : '',
+    totalAmount: model.total_amount,
+    status: model.status ? model.status : '',
+    category: model.category ? model.category : '',
+    date: model.date,
+    createdAt: model.created_at,
+    updatedAt: model.updated_at ? model.updated_at : undefined,
+    idReport: model.id_report,
+    urlFile: model.url_file ? model.url_file : '',
+  };
+}
+
+export function mapExpenseReportEntityFromDbModel(model: RawExpenseReport): ExpenseReport {
+  return {
+    id: model.id,
+    title: model.title,
+    description: model.description,
+    startDate: model.start_date,
+    endDate: model.end_date ? model.end_date : undefined,
+    status: model.status ? model.status : undefined,
+    urlVoucher: model.url_voucher ? model.url_voucher : '',
+    idEmployee: model.id_employee,
+    employeeFirstName: model.employee?.first_name ? model.employee.first_name : '',
+    employeeLastName: model.employee?.last_name ? model.employee.last_name : '',
+    expenses: model.expense ? model.expense.map(mapExpenseEntityFromDbModel) : [],
+  };
+}

--- a/src/core/infra/mappers/expense-entity-from-db-model.mapper.ts
+++ b/src/core/infra/mappers/expense-entity-from-db-model.mapper.ts
@@ -1,4 +1,5 @@
 import { expense } from '@prisma/client';
+import { ExpenseReportStatus } from '../../../utils/enums/index';
 import { ExpenseEntity, ExpenseReport, RawExpenseReport } from '../../domain/entities/expense.entity';
 
 export function mapExpenseEntityFromDbModel(model: expense): ExpenseEntity {
@@ -25,7 +26,7 @@ export function mapExpenseReportEntityFromDbModel(model: RawExpenseReport): Expe
     description: model.description,
     startDate: model.start_date,
     endDate: model.end_date ? model.end_date : undefined,
-    status: model.status ? model.status : undefined,
+    status: model.status as ExpenseReportStatus,
     urlVoucher: model.url_voucher ? model.url_voucher : '',
     idEmployee: model.id_employee,
     employeeFirstName: model.employee?.first_name ? model.employee.first_name : '',

--- a/src/core/infra/repositories/expense.repository.ts
+++ b/src/core/infra/repositories/expense.repository.ts
@@ -1,0 +1,35 @@
+import { Prisma } from '../../..';
+import { ExpenseReport } from '../../domain/entities/expense.entity';
+import { NotFoundError } from '../../errors/not-found.error';
+import { mapExpenseReportEntityFromDbModel } from '../mappers/expense-entity-from-db-model.mapper';
+
+const RESOURCE_NAME = 'Expense report';
+
+/**
+ * Finds a expense report by id
+ * @version 1.0.0
+ * @returns {Promise<ExpenseReport>} a promise that resolves in a expense report entity.
+ */
+async function findById(id: string): Promise<ExpenseReport> {
+  try {
+    const data = await Prisma.expense_report.findUnique({
+      where: {
+        id: id,
+      },
+      include: {
+        expense: true,
+        employee: true,
+      },
+    });
+
+    if (!data) {
+      throw new NotFoundError(RESOURCE_NAME);
+    }
+
+    return mapExpenseReportEntityFromDbModel(data);
+  } catch (error: unknown) {
+    throw new Error(`${RESOURCE_NAME} repository error`);
+  }
+}
+
+export const ExpenseRepository = { findById };

--- a/src/utils/enums/index.ts
+++ b/src/utils/enums/index.ts
@@ -57,3 +57,10 @@ export enum ProjectPeriodicity {
   TWELVE_MONTHS = '12 months',
   WHEN_NEEDED = 'When needed',
 }
+
+export enum ExpenseReportStatus {
+  ACCEPTED = 'Accepted',
+  PAYED = 'Payed',
+  PENDING = 'Pending',
+  REJECTED = 'Rejected',
+}


### PR DESCRIPTION
## Expenses-RF32: Endpoint for expenseReport data by id
ESTE PR ES EL QUE INCORRECTAMENTE SE HIZO A DEVELOP, SOLO QUE AHORA SE HARÁ A MBI

[Feature/RF32]: Added an endpoint for getting expenseReport data by id. Added base logic for expenses and all of it's corresponding files

### Description

RF32: As a user I want to consult the details of a travel expenses report.

### Changes

- Added `prisma/migrations/20240522045959_expenses_update_fields/migration.sql`. Migration to support corresponding fields for expenses according to updated ER Model
- Modified `prisma/schema.prisma` as a result of the previous migration
- Modified `src/api/routes/index.routes.ts`. Added endpoint for /expense/
- Added `src/api/routes/expense.routes.ts`
- Added `src/api/controllers/expense.controller.ts`
- Added `src/core/domain/entities/expense.entity.ts`
- Added `src/core/app/services/expense.service.ts`
- Added `src/core/infra/mappers/expense-entity-from-db-model.mapper.ts`
- Added `src/core/infra/repositories/expense.repository.ts`
- Modified `src/utils/enums/index.ts`. Added enum for ExpenseReportStatus
- Added `src/core/app/services/__tests__/expense.service.test.ts` for testing services

### Story Points

8

### Testing

A test was designed and run in which the service was tested. Mocha&Chai was used for this automated test. The test succeeds
![image](https://github.com/Black-Dot-2024/Zeitgeist-Backend/assets/91692094/dad36336-6718-4d09-b980-9edcc63087e8)


### Dependencies

None (It will be the PR that lays the foundation for the entire expenses module)


### Done?

- [x] La tarea ha sido completamente implementada, cumpliendo con todos los requisitos y funcionalidades definidos.
- [x] Todas las pruebas pasan, siguiendo el plan de pruebas.
- [x] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [x] La documentación ha sido actualizada (si corresponde).
- [x] Se han cerrado todos los issues (si aplicara) creados en el defect Log.
- [x] Se ha creado o actualizado la documentación necesaria relacionada con la tarea.
- [x] Se ha mapeado en las herramientas de trazabilidad [RTM](https://docs.google.com/spreadsheets/d/1Dqh-fTPP5tEfbQ_cVwz-jI74CmAe0DkSAw2a-vVrbVk/edit?usp=sharing), [PVG](https://docs.google.com/spreadsheets/d/1mFO9Bb7gJysk4sDaJ2z7ufl0epSR40XKp3J-r4IxFVc/edit#gid=1369995251)

### Screenshot
![image](https://github.com/Black-Dot-2024/Zeitgeist-Backend/assets/91692094/15e8d86c-bb7d-45a6-ab12-273122f2f81d)