### PR TITLE
fix(RF32): Add accounting role to access all expense reports

### DIFF
--- a/src/core/app/services/expense.service.ts
+++ b/src/core/app/services/expense.service.ts
@@ -67,7 +67,11 @@ async function getReportById(reportId: string, email: string): Promise<ExpenseRe
       ExpenseRepository.findById(reportId),
     ]);
 
-    if (role.title.toUpperCase() != SupportedRoles.ADMIN.toUpperCase() && expenseReport.idEmployee != employee?.id) {
+    if (
+      role.title.toUpperCase() != SupportedRoles.ADMIN.toUpperCase() &&
+      role.title.toUpperCase() != SupportedRoles.ACCOUNTING.toUpperCase() &&
+      expenseReport.idEmployee != employee?.id
+    ) {
       throw new Error('Unauthorized employee');
     }
 


### PR DESCRIPTION
## [Fix/RF32]: Add accounting role to access all expense reports

[Fix/RF32]: Add accounting role to access all expense reports

### Descripción

\-

### Cambios realizados

- Se modifica `src/core/app/services/expense.service.ts`, Permitir accounting también

### Story Points

\-

### Criterios de aceptación

- closes: #223 

### Dependencias

Ninguna

### Screen de pruebas y/o notas

![image](https://github.com/Black-Dot-2024/Zeitgeist-Backend/assets/91692094/31708dd4-60a2-4b0d-a81b-b2a74c79a48b)